### PR TITLE
Fix notification header spacing

### DIFF
--- a/styles/controls.less
+++ b/styles/controls.less
@@ -48,7 +48,6 @@
 
 .sheet-toolbar{
   border: none;
-  margin-bottom: 8px;
   .btn-toolbar{
     border-radius: @btn-border-radius!important;
     padding: @btn-padding;

--- a/styles/footer.less
+++ b/styles/footer.less
@@ -1,3 +1,3 @@
-.sheet, [name="Footer"]{
+[name="Footer"]{
   margin-top: -8px;
 }


### PR DESCRIPTION
Remove margin from the `Toolbar` so that there is no extra spacing between it and the notification `Header`.
