### PR TITLE
Add theme colors and update variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "displayName": "Ido",
   "name": "N1-Ido",
   "theme": "Ido",
   "version": "0.0.6",

--- a/styles/controls.less
+++ b/styles/controls.less
@@ -33,6 +33,7 @@
     }
   }
 }
+
 @media(max-width: 966px){
   .search-bar .menu .header-container input.empty{
     padding-left: 30%;
@@ -75,9 +76,6 @@
     margin-top: @toolbar-btns-margin-top;
     margin-left: @toolbar-btns-margin-left;
     margin-bottom: @toolbar-btns-margin-bottom;
-  }
-  .btn-toolbar:only-of-type{
-    margin-right: 18px;
   }
   .message-toolbar-items{
     order: @toolbar-items-order;

--- a/styles/preferences.less
+++ b/styles/preferences.less
@@ -12,3 +12,16 @@
     }
   }
 }
+
+.preferences-wrap .preferences-sidebar {
+  .item {
+    border-bottom: none;
+    color: @white;
+    &.active {
+      background: @sidebar-active-item-bg !important;
+      .name {
+        color: @white !important;
+      }
+    }
+  }
+}

--- a/styles/sidebar.less
+++ b/styles/sidebar.less
@@ -46,11 +46,6 @@
   color: @sidebar-fg-color;
 }
 
-.account-sidebar {
-  background: @sidebar-bg;
-}
-
-
 .sheet {
   margin-top: 0;
 }
@@ -58,34 +53,26 @@
 .layout-mode-split {
   .sheet-toolbar-container [data-column="1"],
   .column-ThreadList {
-    border-right: 2px solid @border-color;
+    border-right: 1px solid @border-color;
   }
 }
 
 [data-column="0"] .item-container, #account-switcher{
-  background: @sidebar-bg!important;
+  background: @sidebar-bg !important;
   color: @sidebar-fg-color;
   padding-bottom: 3px;
 }
-
-#account-switcher, .account-sidebar{
-  background: @sidebar-bg;
-}
-
-
 
 #account-switcher .heading, .account-sidebar .heading{
   color: @sidebar-heading-fg;
 }
 
 .account-sidebar-sections {
-  background: @sidebar-bg;
   section {
     img.content-mask{
       background-color: @sidebar-fg-color!important;
     }
     .item-container {
-      background: @sidebar-bg;
       .disclosure-triangle {
         margin-left: 6px;
         margin-right: -16px;
@@ -120,7 +107,6 @@
             margin-left: -105.7% !important;
           }
 
-
           .item-count-box {
             background: transparent !important;
             color: @white !important;
@@ -141,4 +127,8 @@
 .nylas-outline-view .heading {
   padding-bottom: 10px;
   font-size: 13px;
+}
+
+.disclosure-triangle div {
+  border-left: 7px solid rgba(255, 255, 255, 0.25);
 }

--- a/styles/theme-colors.less
+++ b/styles/theme-colors.less
@@ -1,0 +1,1 @@
+@component-active-color: #ecf3fa;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -11,7 +11,7 @@
 @text-color-inverse-subtle: darken(@taiga-light, 30%);
 @text-color-inverse-very-subtle: darken(@taiga-light, 20%);
 
-@panel-background-color: @white;
+@panel-background-color: @sidebar-bg;
 @toolbar-background-color: @white;
 
 @btn-default-bg-color: @white;


### PR DESCRIPTION
Hey, @edipox! I'm part of the Nylas team, and we're about to land a new visual theme picker that'll allow people to preview and view color palettes for themes. We pull a few major colors from the theme's UI variables to create the palette, but we've also added a way to override them manually with a `theme-colors.less` file for themes. This PR's mainly intended to use the `@panel-background-color` UI variable and override the `@component-active-color` variable for the theme picker swatch.
