### PR TITLE
💄  fix grey text againist background in preferences

### DIFF
--- a/styles/preferences.less
+++ b/styles/preferences.less
@@ -17,8 +17,10 @@
   .preferences-sidebar, .container-preference-tabs .preferences-tabs {
     .item {
       border-bottom: none;
+      color: @white;
       &.active {
-        color: @white;
+        font-weight: bold;
+        font-size: 1.2rem;
         background: @sidebar-active-item-bg !important;
         .name {
           color: @white !important;


### PR DESCRIPTION
This should fix #35.

## changes I've made
- set the tab text color by default to `@white`
- increase font size and weight at active items

## preview
![Screenshot](https://user-images.githubusercontent.com/47633893/116082568-d9412900-a69b-11eb-8af5-a1d4edc00ad5.png)
